### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+
   def index
     @items = Item.all
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,33 +1,33 @@
 class ItemsController < ApplicationController
-
   def index
     @items = Item.all
   end
-  
+
   def new
     @item = Item.new
   end
+
   def create
     Item.create(item_params)
   end
 
-  #def destroy
-    #@item = Item.find(params[:id])
-    #item.destroy
-  #end
-  #def edit
-    #@item = item.find(params[:id])
-  #end
-  #def update
-    #item = Item.find(params[:id])
-    #item.update(item_params)
-  #end
-  #def show
-    #@item = Item.find(params[:id])
-  #end
+  # def destroy
+  # @item = Item.find(params[:id])
+  # item.destroy
+  # end
+  # def edit
+  # @item = item.find(params[:id])
+  # end
+  # def update
+  # item = Item.find(params[:id])
+  # item.update(item_params)
+  # end
+  # def show
+  # @item = Item.find(params[:id])
+  # end
 
   private
-  
+
   def item_params
     params.require(:item).permit(:name, :introduction, :item_condition_id, :category_id, :price, :postage_payer_id, :shipment_id, :preparation_day_id)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
-  end
+    @items = Item.order("created_at DESC")
 
   def new
     @item = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,4 +2,32 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all
   end
+  
+  def new
+    @item = Item.new
+  end
+  def create
+    Item.create(item_params)
+  end
+
+  #def destroy
+    #@item = Item.find(params[:id])
+    #item.destroy
+  #end
+  #def edit
+    #@item = item.find(params[:id])
+  #end
+  #def update
+    #item = Item.find(params[:id])
+    #item.update(item_params)
+  #end
+  #def show
+    #@item = Item.find(params[:id])
+  #end
+
+  private
+  
+  def item_params
+    params.require(:item).permit(:name, :introduction, :item_condition_id, :category_id, :price, :postage_payer_id, :shipment_id, :preparation_day_id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
     validates :first_name
     validates :last_name
   end
-    with_options presence: true, format: { with: /\A[ァ-ン]+\z/ } do
+  with_options presence: true, format: { with: /\A[ァ-ン]+\z/ } do
     validates :first_name_kana
     validates :last_name_kana
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,6 @@
 <%= render "shared/header" %>
 <div class='main'>
 
-  <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
   <div class='title-contents'>
     <h2 class='service-title'>
       人生を変えるフリマアプリ
@@ -17,9 +16,7 @@
       <%= link_to image_tag("dl-android.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面上部の「人生を変えるフリマアプリ」帯部分  %>
 
-  <%# FURIMAが選ばれる3つの理由部分 %>
   <div class='select-reason-contents'>
     <h2 class='title'>
       FURIMAが選ばれる3つの理由
@@ -60,9 +57,7 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAが選ばれる3つの理由部分 %>
 
-  <%# 画面中央の「会員数日本一位」帯部分 %>
   <div class='ad-contents'>
     <h2 class='ad-title'>
       会員数日本一位
@@ -81,7 +76,6 @@
       <%= link_to image_tag("dl-android.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面中央の「会員数日本一位」帯部分 %>
 
   <%# FURIMAの特徴 %>
   <div class='feature-contents'>
@@ -118,15 +112,14 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAの特徴 %>
 
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -152,8 +145,8 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -77,7 +77,6 @@
     </div>
   </div>
 
-  <%# FURIMAの特徴 %>
   <div class='feature-contents'>
     <h2 class='title'>
       FURIMAの特徴
@@ -113,22 +112,22 @@
     </ul>
   </div>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <% @items.each do |item| %>
+    <% if @item.present? %>
+    <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+      <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <%= image_tag "item-sample.png", class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
@@ -136,20 +135,20 @@
           <h3 class='item-name'>
             <%= "商品名" %>
           </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
+        <div class='item-price'>
+          <span><%= "販売価格" %>円<br>(税込み)</span>
+        <div class='star-btn'>
+          <%= image_tag "star.png", class:"star-icon" %>
+          <span class='star-count'>0</span>
+        </div>
+        </div>
         </div>
         <% end %>
         <% end %>
       </li>
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% else %>
+
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -167,12 +166,11 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+    <% end %>
     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
+
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
   <a href="#">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
+  resources :items
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nickname {Faker::Name.last_name}
-    email {Faker::Internet.free_email}
-    password {"00000a"}
-    password_confirmation {password}
-    first_name { "ぜんかく" }
-    last_name { "ぜんかく" }
-    first_name_kana { "ゼンカクカナ" }
-    last_name_kana { "ゼンカクカナ" }
-    birthday { "2020-01-01" }
+    nickname { Faker::Name.last_name }
+    email { Faker::Internet.free_email }
+    password { '00000a' }
+    password_confirmation { password }
+    first_name { 'ぜんかく' }
+    last_name { 'ぜんかく' }
+    first_name_kana { 'ゼンカクカナ' }
+    last_name_kana { 'ゼンカクカナ' }
+    birthday { '2020-01-01' }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,101 +6,101 @@ RSpec.describe User, type: :model do
       @user = FactoryBot.build(:user)
     end
 
-  #正常系
-    it "必要な情報、nickname〜bithdayまでがきちんと存在すれば登録できること" do
+    # 正常系
+    it '必要な情報、nickname〜bithdayまでがきちんと存在すれば登録できること' do
       expect(@user).to be_valid
     end
 
-  #異常系
-    it "nicknameが空では登録できないこと" do
-      @user.nickname = ""
+    # 異常系
+    it 'nicknameが空では登録できないこと' do
+      @user.nickname = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("Nickname can't be blank")
     end
-    it "emailが空では登録できないこと" do
-      @user.email = ""
+    it 'emailが空では登録できないこと' do
+      @user.email = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("Email can't be blank")
     end
-    it "emailに@が入っていないと登録できないこと" do
-      @user.email = "aaaaa.com"
+    it 'emailに@が入っていないと登録できないこと' do
+      @user.email = 'aaaaa.com'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Email is invalid")
+      expect(@user.errors.full_messages).to include('Email is invalid')
     end
-    it "emailが重複していたら登録できないこと" do
+    it 'emailが重複していたら登録できないこと' do
       @user.save
       another_user = FactoryBot.build(:user)
       another_user.email = @user.email
       another_user.valid?
-      expect(another_user.errors.full_messages).to include("Email has already been taken")
+      expect(another_user.errors.full_messages).to include('Email has already been taken')
     end
-    it "passwordが空では登録できないこと" do
-      @user.password = ""
+    it 'passwordが空では登録できないこと' do
+      @user.password = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("Password can't be blank")
     end
-    it "passwordが存在してもpassword_confirmationが空では登録できないこと" do
-      @user.password_confirmation = ""
+    it 'passwordが存在してもpassword_confirmationが空では登録できないこと' do
+      @user.password_confirmation = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
     end
-    it "passwordが5文字以下では登録できないこと" do
-      @user.password = "0000a"
+    it 'passwordが5文字以下では登録できないこと' do
+      @user.password = '0000a'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+      expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
     end
-    it "passwordが数字だけでは登録できないこと" do
-      @user.password = "000000"
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-    end
-    it "passwordが半角英字だけでは登録できないこと" do
-      @user.password = "aaaaaa"
+    it 'passwordが数字だけでは登録できないこと' do
+      @user.password = '000000'
       @user.valid?
       expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
     end
-    it "first_nameが空では登録できないこと" do
-      @user.first_name = ""
+    it 'passwordが半角英字だけでは登録できないこと' do
+      @user.password = 'aaaaaa'
+      @user.valid?
+      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+    end
+    it 'first_nameが空では登録できないこと' do
+      @user.first_name = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("First name can't be blank")
     end
-    it "first_nameが半角英数字だと登録できないこと" do
-      @user.first_name = "aaa"
+    it 'first_nameが半角英数字だと登録できないこと' do
+      @user.first_name = 'aaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name is invalid")
+      expect(@user.errors.full_messages).to include('First name is invalid')
     end
-    it "last_nameが空では登録できないこと" do
-      @user.last_name = ""
+    it 'last_nameが空では登録できないこと' do
+      @user.last_name = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("Last name can't be blank")
     end
-    it "last_nameが半角英数字だと登録できないこと" do
-      @user.last_name = "aaa"
+    it 'last_nameが半角英数字だと登録できないこと' do
+      @user.last_name = 'aaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Last name is invalid")
+      expect(@user.errors.full_messages).to include('Last name is invalid')
     end
-    it "first_name_kanaが空では登録できないこと" do
-      @user.first_name_kana = ""
+    it 'first_name_kanaが空では登録できないこと' do
+      @user.first_name_kana = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("First name kana can't be blank")
     end
-    it "first_name_kanaが全角カタカナでないと登録できないこと" do
-      @user.first_name_kana = "aaa"
+    it 'first_name_kanaが全角カタカナでないと登録できないこと' do
+      @user.first_name_kana = 'aaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name kana is invalid")
+      expect(@user.errors.full_messages).to include('First name kana is invalid')
     end
-    it "last_name_kanaが空では登録できないこと" do
-      @user.last_name_kana = ""
+    it 'last_name_kanaが空では登録できないこと' do
+      @user.last_name_kana = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("Last name kana can't be blank")
     end
-    it "last_name_kanaが全角カタカナでないと登録できないこと" do
-      @user.last_name_kana = "aaa"
+    it 'last_name_kanaが全角カタカナでないと登録できないこと' do
+      @user.last_name_kana = 'aaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Last name kana is invalid")
+      expect(@user.errors.full_messages).to include('Last name kana is invalid')
     end
-    it "birthdayが空では登録できないこと" do
-      @user.birthday = ""
+    it 'birthdayが空では登録できないこと' do
+      @user.birthday = ''
       @user.valid?
       expect(@user.errors.full_messages).to include("Birthday can't be blank")
     end


### PR DESCRIPTION
#what
商品一覧表示機能の実装

#why
今後実装していく商品の登録や編集や削除を確認できる様に。

＃商品一覧画面実装、商品がないため分岐が確認できるスクショはありません・・・。
　https://gyazo.com/d6817f238ff05287fa513a31e11de142
「売却済みの商品は、『sold out』の文字が表示されるようになっていること」未実装です